### PR TITLE
2.0.7 : Fix slug de TVA pour retourner du contenu

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.infologique.TVAgo" name="TVA+" version="2.0.6" provider-name="anisite, MaximeLussier">
+<addon id="plugin.infologique.TVAgo" name="TVA+" version="2.0.7" provider-name="anisite, MaximeLussier">
   <requires>
     <import addon="script.module.simplejson" version="3.16.1"/>
     <import addon="script.module.inputstreamhelper" version="0.5.2"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+2.0.7 ====
+- Fix slug pour TVA
 2.0.6 ====
 - Fix régression Kodi 18
 

--- a/resources/lib/content.py
+++ b/resources/lib/content.py
@@ -260,8 +260,10 @@ def LoadMainMenu(filtres):
                             'url' : carte['slug'],
                             'filtres' : GetCopy(filtres)
                         }
+            
+            if carte['slug'] == '/tva': newItem['filtres']['content']['url'] = '/accueil/qubtv-emissions'
+            else: newItem['filtres']['content']['url'] = carte['slug']
 
-            newItem['filtres']['content']['url'] = carte['slug'].replace('/tva', '/accueil/qubtv-emissions')
             newItem['isDir'] = True
             newItem['sortable'] = False
             newItem['fanart'] = xbmcaddon.Addon().getAddonInfo('path') + '/resources/fanart.jpg'

--- a/resources/lib/content.py
+++ b/resources/lib/content.py
@@ -261,7 +261,7 @@ def LoadMainMenu(filtres):
                             'filtres' : GetCopy(filtres)
                         }
 
-            newItem['filtres']['content']['url'] = carte['slug']
+            newItem['filtres']['content']['url'] = carte['slug'].replace('/tva', '/accueil/qubtv-emissions')
             newItem['isDir'] = True
             newItem['sortable'] = False
             newItem['fanart'] = xbmcaddon.Addon().getAddonInfo('path') + '/resources/fanart.jpg'


### PR DESCRIPTION
Voici un fix que je viens de confirmer comme fonctionnel, par contre, ce n'est pas parfait, je crois que ca retourne tout, de toutes les chaines dans TVA, mais c'est mieux que de ne rien avoir.